### PR TITLE
add n2-style live progress display

### DIFF
--- a/otherlibs/stdune/src/time.ml
+++ b/otherlibs/stdune/src/time.ml
@@ -3,6 +3,7 @@ type t = float
 let now () = Unix.gettimeofday ()
 let to_secs t = t
 let of_epoch_secs x = x
+let compare = Float.compare
 let diff = ( -. )
 
 module Span = struct

--- a/otherlibs/stdune/src/time.mli
+++ b/otherlibs/stdune/src/time.mli
@@ -3,6 +3,7 @@ type t
 val now : unit -> t
 val to_secs : t -> float
 val of_epoch_secs : float -> t
+val compare : t -> t -> Ordering.t
 
 module Span : sig
   type t

--- a/src/dune_console/progress.ml
+++ b/src/dune_console/progress.ml
@@ -4,24 +4,61 @@ module No_flush = struct
   let status_line = ref Pp.nop
   let start () = ()
   let status_line_len = ref 0
+  
+  (* n2-style: track number of lines we've printed for moving cursor back up.
+     After printing, we move cursor up this many lines so the next print
+     overwrites the status. *)
+  let status_lines_count = ref 0
+  
+  (* Track whether we're in multi-line mode. Once we enter multi-line mode,
+     we must always use multi-line clearing (even if count is temporarily 0)
+     because cursor position is managed differently. *)
+  let multiline_mode = ref false
 
   let hide_status_line () =
-    if !status_line_len > 0 then Printf.eprintf "\r%*s\r" !status_line_len ""
+    (* n2-style: always start by clearing from current position.
+       This works regardless of where the cursor is (even after external output).
+       No need to try to move cursor up first - just clear what's below. *)
+    if !multiline_mode then begin
+      Printf.eprintf "\r\x1b[J";
+      status_lines_count := 0
+    end
+    else if !status_line_len > 0 then 
+      Printf.eprintf "\r%*s\r" !status_line_len ""
   ;;
 
-  let show_status_line () = if !status_line_len > 0 then Ansi_color.prerr !status_line
+  let show_status_line () = 
+    if !status_lines_count > 0 || !status_line_len > 0 then begin
+      Ansi_color.prerr !status_line;
+      (* n2-style: after printing N lines, move cursor back up N lines.
+         This positions us at the start of the status block for next update. *)
+      if !status_lines_count > 0 then
+        Printf.eprintf "\x1b[%dA" !status_lines_count
+    end
 
   let set_status_line = function
     | None ->
       hide_status_line ();
       status_line := Pp.nop;
-      status_line_len := 0
+      status_line_len := 0;
+      status_lines_count := 0;
+      multiline_mode := false
     | Some line ->
       let line = Pp.map_tags line ~f:User_message.Print_config.default in
-      let line_len = String.length (Format.asprintf "%a" Pp.to_fmt line) in
+      let formatted = Format.asprintf "%a" Pp.to_fmt line in
+      let line_len = String.length formatted in
+      (* Count newlines for multi-line status *)
+      let lines = 
+        let count = ref 0 in
+        String.iter formatted ~f:(fun c -> if Char.equal c '\n' then incr count);
+        !count
+      in
+      (* Enter multi-line mode if we have multiple lines *)
+      if lines > 0 then multiline_mode := true;
       hide_status_line ();
       status_line := line;
       status_line_len := line_len;
+      status_lines_count := lines;
       show_status_line ()
   ;;
 
@@ -30,7 +67,6 @@ module No_flush = struct
   let print_user_message msg =
     hide_status_line ();
     Dumb.No_flush.print_user_message msg;
-    show_status_line ()
   ;;
 
   let reset () = Dumb.reset ()

--- a/src/dune_engine/build_system.ml
+++ b/src/dune_engine/build_system.ml
@@ -438,6 +438,7 @@ end = struct
                }
              in
              let build_deps deps = Memo.run (build_deps deps) in
+             (* n2-style: status line handles display, no per-completion logging needed *)
              Action_exec.exec input ~build_deps
            in
            let* action_exec_result = Action_exec.Exec_result.ok_exn action_exec_result in

--- a/src/dune_threaded_console/dune_threaded_console.ml
+++ b/src/dune_threaded_console/dune_threaded_console.ml
@@ -173,8 +173,11 @@ let progress ~frames_per_second =
       (* The current console doesn't react to user events so we just sleep until
          the next loop iteration. Because it doesn't react to user input, it cannot
          modify the UI state, and as a consequence doesn't need the mutex. *)
-      let handle_user_events ~now ~time_budget (_ : Mutex.t) (_ : state) =
+      let handle_user_events ~now ~time_budget (_ : Mutex.t) (state : state) =
         Unix.sleepf (Time.Span.to_secs time_budget);
+        (* n2-style: re-evaluate the Live thunk to update elapsed times *)
+        Dune_console.Status_line.refresh ();
+        state.dirty <- true;
         Time.add now time_budget
       ;;
     end)


### PR DESCRIPTION
- add Time.compare for timestamp comparison
- add Running_jobs module import
- visual progress bar: [====----    ]
- live task list with elapsed times and color coding
- queue depth: done/running/queued counts
- build elapsed time display
- critical path indicator for low parallelism
- smart path truncation preserving filenames
- multi-line status line support
- periodic refresh for elapsed time updates